### PR TITLE
Portal 931/user auth flow

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import Dashboard from "./Dashboard";
 import { Landing } from "./Landing";
 import Callback from "./Callback";
+import Profile from "./Profile";
 
 function App() {
   return (
@@ -13,7 +14,9 @@ function App() {
       <Routes>
         <Route path="/" element={<Landing />}></Route>
         <Route path="/oauth_callback" element={<Callback />}></Route>
-        <Route path="/dashboard" element={<Dashboard />}></Route>
+        <Route path="/dashboard" element={<Dashboard />}>
+          <Route path="/dashboard/profile" element={<Profile />}></Route>
+        </Route>
       </Routes>
     </Router>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,12 +5,14 @@ import "./App.css";
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import Dashboard from "./Dashboard";
 import { Landing } from "./Landing";
+import Callback from "./Callback";
 
 function App() {
   return (
     <Router>
       <Routes>
         <Route path="/" element={<Landing />}></Route>
+        <Route path="/oauth_callback" element={<Callback />}></Route>
         <Route path="/dashboard" element={<Dashboard />}></Route>
       </Routes>
     </Router>

--- a/src/Callback.tsx
+++ b/src/Callback.tsx
@@ -2,20 +2,23 @@ import { useAuth } from "react-oidc-context";
 import { useEffect } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 
+// The main purpose of this component is to handle the redirect from SAMS and register an event handler
+// for when the user profile has been successfuly populated.
 function Callback() {
   const auth = useAuth();
   const navigate = useNavigate();
   const location = useLocation();
 
+  // In case the user tried to access a page directly.
   const from = location.state?.from?.pathname || "/dashboard";
 
   useEffect(() => {
     return auth.events.addUserLoaded(() => {
       navigate(from, { replace: true });
     });
-  });
+  }, []);
 
-  return <></>;
+  return <></>; // Can possibly add a loading message here in the future.
 }
 
 export default Callback;

--- a/src/Callback.tsx
+++ b/src/Callback.tsx
@@ -1,0 +1,21 @@
+import { useAuth } from "react-oidc-context";
+import { useEffect } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+
+function Callback() {
+  const auth = useAuth();
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const from = location.state?.from?.pathname || "/dashboard";
+
+  useEffect(() => {
+    return auth.events.addUserLoaded(() => {
+      navigate(from, { replace: true });
+    });
+  });
+
+  return <></>;
+}
+
+export default Callback;

--- a/src/Callback.tsx
+++ b/src/Callback.tsx
@@ -16,7 +16,7 @@ function Callback() {
     return auth.events.addUserLoaded(() => {
       navigate(from, { replace: true });
     });
-  }, []);
+  }, [auth.events, from, navigate]);
 
   return <></>; // Can possibly add a loading message here in the future.
 }

--- a/src/Dashboard.tsx
+++ b/src/Dashboard.tsx
@@ -56,7 +56,7 @@ function Dashboard() {
       icon: "user",
       iconPosition: "left",
       text: "Your Profile",
-      onClick: () => navigate("/dashboard/profile"),
+      onClick: () => navigate("/dashboard/profile"), // Not sure if this is the final structure, but it's good enough for demo purposes.
       badgeCount: 0,
     },
     {

--- a/src/Dashboard.tsx
+++ b/src/Dashboard.tsx
@@ -123,9 +123,9 @@ function Dashboard() {
               <h2>New to DEX?</h2>
               <Button
                 className={styles["request-access-btn"]}
-                ariaLabel="request access"
+                ariaLabel="take a tour"
                 variation="outline">
-                Request access
+                Take a tour
               </Button>
               <Button
                 className={styles["learn-more-btn"]}

--- a/src/Dashboard.tsx
+++ b/src/Dashboard.tsx
@@ -16,11 +16,12 @@ import {
 
 import { useState } from "react";
 import { useAuth } from "react-oidc-context";
-import { Navigate, useLocation } from "react-router-dom";
+import { Navigate, Outlet, useLocation, useNavigate } from "react-router-dom";
 
 function Dashboard() {
   const auth = useAuth();
   const location = useLocation();
+  const navigate = useNavigate();
 
   if (!auth.isAuthenticated) {
     return <Navigate to="/" state={{ from: location }} replace />;
@@ -55,7 +56,7 @@ function Dashboard() {
       icon: "user",
       iconPosition: "left",
       text: "Your Profile",
-      onClick: undefined,
+      onClick: () => navigate("/dashboard/profile"),
       badgeCount: 0,
     },
     {
@@ -111,26 +112,30 @@ function Dashboard() {
             popupMenuItems={popupMenuItems}
           />
         </section>
-        <section className="main_content">
-          <div className="box">
-            <h2>TBD</h2>
-          </div>
-          <div className="box">
-            <h2>New to DEX?</h2>
-            <Button
-              className={styles["request-access-btn"]}
-              ariaLabel="request access"
-              variation="outline">
-              Request access
-            </Button>
-            <Button
-              className={styles["learn-more-btn"]}
-              ariaLabel="learn more"
-              variation="outline">
-              Learn more
-            </Button>
-          </div>
-        </section>
+        {location.pathname.includes("profile") ? (
+          <Outlet />
+        ) : (
+          <section className="main_content">
+            <div className="box">
+              <p>Welcome {auth.user?.profile.email}</p>
+            </div>
+            <div className="box">
+              <h2>New to DEX?</h2>
+              <Button
+                className={styles["request-access-btn"]}
+                ariaLabel="request access"
+                variation="outline">
+                Request access
+              </Button>
+              <Button
+                className={styles["learn-more-btn"]}
+                ariaLabel="learn more"
+                variation="outline">
+                Learn more
+              </Button>
+            </div>
+          </section>
+        )}
       </div>
     </div>
   );

--- a/src/Dashboard.tsx
+++ b/src/Dashboard.tsx
@@ -22,12 +22,11 @@ function Dashboard() {
   const auth = useAuth();
   const location = useLocation();
   const navigate = useNavigate();
+  const [profileHeaderPopupOpen, setProfileHeaderPopupOpen] = useState(false);
 
   if (!auth.isAuthenticated) {
     return <Navigate to="/" state={{ from: location }} replace />;
   }
-
-  const [profileHeaderPopupOpen, setProfileHeaderPopupOpen] = useState(false);
 
   const logo = <ProfileHeaderLogo image={dexLogo} classNames={["dex-logo"]} />;
 

--- a/src/Dashboard.tsx
+++ b/src/Dashboard.tsx
@@ -15,8 +15,17 @@ import {
 } from "@us-gov-cdc/cdc-react";
 
 import { useState } from "react";
+import { useAuth } from "react-oidc-context";
+import { Navigate, useLocation } from "react-router-dom";
 
 function Dashboard() {
+  const auth = useAuth();
+  const location = useLocation();
+
+  if (!auth.isAuthenticated) {
+    return <Navigate to="/" state={{ from: location }} replace />;
+  }
+
   const [profileHeaderPopupOpen, setProfileHeaderPopupOpen] = useState(false);
 
   const logo = <ProfileHeaderLogo image={dexLogo} classNames={["dex-logo"]} />;

--- a/src/Profile.tsx
+++ b/src/Profile.tsx
@@ -1,0 +1,19 @@
+import { useAuth } from "react-oidc-context";
+
+function Profile() {
+  const auth = useAuth();
+
+  return (
+    <section style={{ wordBreak: "break-all" }}>
+      {auth.user &&
+        Object.keys(auth.user.profile).map((key) => (
+          <div key={key}>
+            <span>{key}: </span>
+            <span>{JSON.stringify(auth.user?.profile[key])}</span>
+          </div>
+        ))}
+    </section>
+  );
+}
+
+export default Profile;

--- a/src/Profile.tsx
+++ b/src/Profile.tsx
@@ -4,7 +4,7 @@ function Profile() {
   const auth = useAuth();
 
   return (
-    <section style={{ wordBreak: "break-all" }}>
+    <section style={{ wordBreak: "break-all", padding: "1rem" }}>
       {auth.user &&
         Object.keys(auth.user.profile).map((key) => (
           <div key={key}>

--- a/src/Profile.tsx
+++ b/src/Profile.tsx
@@ -4,14 +4,8 @@ function Profile() {
   const auth = useAuth();
 
   return (
-    <section style={{ wordBreak: "break-all", padding: "1rem" }}>
-      {auth.user &&
-        Object.keys(auth.user.profile).map((key) => (
-          <div key={key}>
-            <span>{key}: </span>
-            <span>{JSON.stringify(auth.user?.profile[key])}</span>
-          </div>
-        ))}
+    <section style={{ padding: "1rem" }}>
+      {auth.user && <pre>{JSON.stringify(auth.user.profile, null, 2)}</pre>}
     </section>
   );
 }


### PR DESCRIPTION
Follow-on work for finalizing the initial login flow.  Now, the user is redirected to the dashboard page after successful login.  It also uses the `addUserLoaded` event listener from the react OIDC library so the navigation to the dashboard page occurs only after the user's profile is successfully loaded.  

You can also click the user profile button in the popout menu to go to a nested route that shows all of the user's details.