### PR TITLE
build command for stg

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "simulate": "swa start http://localhost:5173 --run \"yarn dev\" --api-location ./api",
     "build": "tsc && vite build",
     "build:dev": "tsc && vite build --mode dev",
+    "build:stg": "tsc && vite build --mode stg",
     "format:check": "prettier --check \"src/**/*.{js,jsx,ts,tsx,css,scss,json,md}\"",
     "format:write": "prettier \"src/**/*.{js,jsx,ts,tsx,css,scss,json,md}\" --write",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",


### PR DESCRIPTION
Custom command for building the portal app for the stg environment.  For testing, requires a local environment file called .env.stg to be created.