### PR TITLE
Portal 1133/destinationid route

### DIFF
--- a/api/src/functions/getDestination.ts
+++ b/api/src/functions/getDestination.ts
@@ -25,7 +25,6 @@ export async function getDestination(
       url: endpoint,
       method: "get",
       headers: { Authorization: authToken },
-      params: request.query,
     });
 
     return {

--- a/api/src/functions/getDestination.ts
+++ b/api/src/functions/getDestination.ts
@@ -1,0 +1,43 @@
+import {
+  HttpRequest,
+  InvocationContext,
+  HttpResponse,
+  HttpResponseBody,
+} from "@azure/functions";
+import axios from "axios";
+
+export async function getDestination(
+  context: InvocationContext,
+  request: HttpRequest
+): Promise<HttpResponse> {
+  const endpoint = `${process.env["SUPPLEMENTAL_API_URL"]}/destination`;
+  const authToken = request.headers.get("Authorization");
+
+  if (!authToken) {
+    context.error("Request did not contain auth token.");
+    return {
+      status: 403,
+    };
+  }
+
+  try {
+    const statusResponse = await axios({
+      url: endpoint,
+      method: "get",
+      headers: { Authorization: authToken },
+      params: request.query,
+    });
+
+    return {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+      body: statusResponse.data as HttpResponseBody,
+    };
+  } catch (error: unknown) {
+    context.error(error);
+    if (axios.isAxiosError(error)) {
+      return { status: error.response.status, body: error.message };
+    }
+    return { status: 500, body: error as HttpResponseBody };
+  }
+}

--- a/api/src/functions/index.ts
+++ b/api/src/functions/index.ts
@@ -1,6 +1,7 @@
 import { app } from "@azure/functions";
 import { uploadStatus } from "./uploadStatus";
 import { oauthCallback } from "./token";
+import { getDestination } from "./getDestination";
 
 app.http("token", {
   methods: ["GET", "POST"],
@@ -13,4 +14,11 @@ app.http("uploadStatus", {
   authLevel: "function",
   route: "upload/status/{destinationId:alpha}",
   handler: uploadStatus,
+});
+
+app.http("getDestination", {
+  methods: ["GET"],
+  authLevel: "function",
+  route: "upload/destination",
+  handler: getDestination,
 });

--- a/api/src/functions/uploadStatus.ts
+++ b/api/src/functions/uploadStatus.ts
@@ -32,7 +32,7 @@ export async function uploadStatus(
   // Then, send request to Supplemental API given destination ID.
   try {
     const statusResponse = await axios({
-      url: `${process.env["SUPPLEMENTAL_API_URL"]}/destination/${destinationId}`,
+      url: `${process.env["SUPPLEMENTAL_API_URL"]}/status/destination/${destinationId}`,
       method: "get",
       headers: { Authorization: authToken },
       params: {

--- a/api/test/functions/getDestination.test.ts
+++ b/api/test/functions/getDestination.test.ts
@@ -19,9 +19,6 @@ describe("Route: GET Destination ID", () => {
     request = new HttpRequest({
       url: "http://localhost",
       method: "GET",
-      params: {
-        destinationId: "test",
-      },
     });
   });
 

--- a/api/test/functions/getDestination.test.ts
+++ b/api/test/functions/getDestination.test.ts
@@ -63,19 +63,6 @@ describe("Route: GET Destination ID", () => {
       expect(response.body).toHaveLength(0);
     });
 
-    test("should return 200 if authenticated", async () => {
-      server.use(
-        http.get(endpoint, () => {
-          return HttpResponse.json([]);
-        })
-      );
-
-      request.headers.set("Authorization", "12345");
-
-      const response = await getDestination(context, request);
-      expect(response.status).toBe(200);
-    });
-
     test("should fetch a mocked response with 3 destinations", async () => {
       server.use(
         http.get(endpoint, () => {

--- a/api/test/functions/getDestination.test.ts
+++ b/api/test/functions/getDestination.test.ts
@@ -5,7 +5,7 @@ import { server } from "../mocks/node";
 import { describe, beforeEach, test, expect, vi } from "vitest";
 
 describe("Route: GET Destination ID", () => {
-  const endpoint = `${process.env["SUPPLEMENTAL_API_URL"]}/destination`;
+  const supplementalApiEndpoint = `${process.env["SUPPLEMENTAL_API_URL"]}/destination`;
   let context: InvocationContext;
   let request: HttpRequest;
 
@@ -30,7 +30,7 @@ describe("Route: GET Destination ID", () => {
 
     test("should return unauthorized if supplemental API returns unauthorized", async () => {
       server.use(
-        http.get(endpoint, () => {
+        http.get(supplementalApiEndpoint, () => {
           return new HttpResponse(null, {
             status: 401,
             statusText: "Unauthorized",
@@ -50,7 +50,7 @@ describe("Route: GET Destination ID", () => {
     test("should return empty array when no destinations are found", async () => {
       // Init MSW request handlers.
       server.use(
-        http.get(endpoint, () => {
+        http.get(supplementalApiEndpoint, () => {
           return HttpResponse.json([]);
         })
       );
@@ -65,7 +65,7 @@ describe("Route: GET Destination ID", () => {
 
     test("should fetch a mocked response with 3 destinations", async () => {
       server.use(
-        http.get(endpoint, () => {
+        http.get(supplementalApiEndpoint, () => {
           return HttpResponse.json(["dextesting", "ndlp", "pulsenet"]);
         })
       );

--- a/api/test/functions/getDestination.test.ts
+++ b/api/test/functions/getDestination.test.ts
@@ -1,0 +1,101 @@
+import { HttpRequest, InvocationContext } from "@azure/functions";
+import { getDestination } from "../../src/functions/getDestination";
+import { http, HttpResponse } from "msw";
+import { server } from "../mocks/node";
+import { describe, beforeEach, test, expect, vi } from "vitest";
+
+describe("Route: GET Destination ID", () => {
+  const endpoint = `${process.env["SUPPLEMENTAL_API_URL"]}/destination`;
+  let context: InvocationContext;
+  let request: HttpRequest;
+
+  beforeEach(() => {
+    context = new InvocationContext({
+      functionName: "getDestination",
+      invocationId: "getDestinationTestId",
+      logHandler: vi.fn(),
+    });
+
+    request = new HttpRequest({
+      url: "http://localhost",
+      method: "GET",
+      params: {
+        destinationId: "test",
+      },
+    });
+  });
+
+  describe("Non-Auth: GET /api/upload/destination", () => {
+    test("should return 403 Bad Request when no auth token provided in header", async () => {
+      const response = await getDestination(context, request);
+      expect(response.status).toBe(403);
+    });
+
+    test("should return unauthorized if supplemental API returns unauthorized", async () => {
+      server.use(
+        http.get(endpoint, () => {
+          return new HttpResponse(null, {
+            status: 401,
+            statusText: "Unauthorized",
+          });
+        })
+      );
+
+      // Create dummy auth token.
+      request.headers.set("Authorization", "12345");
+
+      const response = await getDestination(context, request);
+      expect(response.status).toBe(401);
+    });
+  });
+
+  describe("Auth: GET /api/upload/destination", () => {
+    test("should return empty array when no upload events found", async () => {
+      // Init MSW request handlers.
+      server.use(
+        http.get(endpoint, () => {
+          return HttpResponse.json([]);
+        })
+      );
+
+      // Create dummy auth token.
+      request.headers.set("Authorization", "12345");
+
+      const response = await getDestination(context, request);
+      expect(response.status).toBe(200);
+      expect(response.body).toHaveLength(0);
+    });
+
+    test("should return 200 if authenticated", async () => {
+      server.use(
+        http.get(endpoint, () => {
+          return HttpResponse.json([]);
+        })
+      );
+
+      request.headers.set("Authorization", "12345");
+
+      const response = await getDestination(context, request);
+      expect(response.status).toBe(200);
+    });
+
+    test("should fetch a mocked response with 3 destinations", async () => {
+      server.use(
+        http.get(endpoint, () => {
+          return HttpResponse.json([
+            { destinationID: "dextesting" },
+            { destinationID: "abc" },
+            { destinationID: "123" },
+          ]);
+        })
+      );
+      request.headers.set("Authorization", "12345");
+
+      const response = await getDestination(context, request);
+
+      expect(response.status).toBe(200);
+      expect(Array.isArray(response.body)).toBe(true);
+      expect(response.body).toHaveLength(3);
+    });
+  });
+});

--- a/api/test/functions/getDestination.test.ts
+++ b/api/test/functions/getDestination.test.ts
@@ -66,11 +66,7 @@ describe("Route: GET Destination ID", () => {
     test("should fetch a mocked response with 3 destinations", async () => {
       server.use(
         http.get(endpoint, () => {
-          return HttpResponse.json([
-            { destinationID: "dextesting" },
-            { destinationID: "abc" },
-            { destinationID: "123" },
-          ]);
+          return HttpResponse.json(["dextesting", "ndlp", "pulsenet"]);
         })
       );
       request.headers.set("Authorization", "12345");
@@ -78,8 +74,15 @@ describe("Route: GET Destination ID", () => {
       const response = await getDestination(context, request);
 
       expect(response.status).toBe(200);
+      expect(response.body).toBeDefined();
       expect(Array.isArray(response.body)).toBe(true);
       expect(response.body).toHaveLength(3);
+
+      if (Array.isArray(response.body)) {
+        response.body.forEach((item) => {
+          expect(typeof item).toBe("string");
+        });
+      }
     });
   });
 });

--- a/api/test/functions/getDestination.test.ts
+++ b/api/test/functions/getDestination.test.ts
@@ -47,7 +47,7 @@ describe("Route: GET Destination ID", () => {
   });
 
   describe("Auth: GET /api/upload/destination", () => {
-    test("should return empty array when no upload events found", async () => {
+    test("should return empty array when no destinations are found", async () => {
       // Init MSW request handlers.
       server.use(
         http.get(endpoint, () => {

--- a/api/test/functions/uploadStatus.test.ts
+++ b/api/test/functions/uploadStatus.test.ts
@@ -5,7 +5,7 @@ import { server } from "../mocks/node";
 import { describe, beforeEach, test, expect, vi } from "vitest";
 
 describe("/upload/status/{destinationId}", () => {
-  const endpoint = `${process.env["SUPPLEMENTAL_API_URL"]}/status/destination/*`;
+  const supplementalApiEndpoint = `${process.env["SUPPLEMENTAL_API_URL"]}/status/destination/*`;
   let context: InvocationContext;
   let request: HttpRequest;
 
@@ -32,7 +32,7 @@ describe("/upload/status/{destinationId}", () => {
   test("should return empty array when no upload events found", async () => {
     // Init MSW request handlers.
     server.use(
-      http.get(endpoint, () => {
+      http.get(supplementalApiEndpoint, () => {
         return HttpResponse.json([]);
       })
     );
@@ -47,7 +47,7 @@ describe("/upload/status/{destinationId}", () => {
 
   test("should return unauthorized if supplemental API returns unauthorized", async () => {
     server.use(
-      http.get(endpoint, () => {
+      http.get(supplementalApiEndpoint, () => {
         return new HttpResponse(null, {
           status: 401,
           statusText: "Unauthorized",

--- a/api/test/functions/uploadStatus.test.ts
+++ b/api/test/functions/uploadStatus.test.ts
@@ -5,6 +5,7 @@ import { server } from "../mocks/node";
 import { describe, beforeEach, test, expect, vi } from "vitest";
 
 describe("/upload/status/{destinationId}", () => {
+  const endpoint = `${process.env["SUPPLEMENTAL_API_URL"]}/status/destination/*`;
   let context: InvocationContext;
   let request: HttpRequest;
 
@@ -31,7 +32,7 @@ describe("/upload/status/{destinationId}", () => {
   test("should return empty array when no upload events found", async () => {
     // Init MSW request handlers.
     server.use(
-      http.get(`${process.env["SUPPLEMENTAL_API_URL"]}/destination/*`, () => {
+      http.get(endpoint, () => {
         return HttpResponse.json([]);
       })
     );
@@ -46,7 +47,7 @@ describe("/upload/status/{destinationId}", () => {
 
   test("should return unauthorized if supplemental API returns unauthorized", async () => {
     server.use(
-      http.get(`${process.env["SUPPLEMENTAL_API_URL"]}/destination/*`, () => {
+      http.get(endpoint, () => {
         return new HttpResponse(null, {
           status: 401,
           statusText: "Unauthorized",


### PR DESCRIPTION
# Add `getDestination` Route

This PR introduces a new `GET` route to our Azure Function backend. This new route will allow us to fetch destination ID's while being authenticated.

## Changes

- A new `GET` route, `/api/upload/destination`.
- Unit tests with mocked auth and http requests/responses have been added.
- The `GET` `uploadStatus` endpoint has been updated to reflect changes to the `SUPPLEMENTAL_API_URL` secret.

## How to Test

### Manual Testing

1. Pull the latest changes from the branch.
2. Install dependencies.
- In root, run `yarn install`.
- Navigate to the API directory `cd api` and run `npm install`.
3. While in the API directory, build the backend `npm run build`.
4. Go back to the root directory `cd ../` and start the server `yarn simulate`.
5. Find your auth token to use with Postman.
6. Hit the endpoint `http://localhost:7071/api/upload/destination` with Postman.

### Automated Mocked Tests
1. Follow steps 1-3 from the Manual Testing section above.
2. Navigate to the API directory `cd api`.
3. Run `npm test`

## References
- [Mock Service Worker - Describing REST API](https://mswjs.io/docs/network-behavior/rest)
- [Microsoft Learn - Azure Functions Node.js developer guide](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node?tabs=javascript%2Cwindows%2Cazure-cli&pivots=nodejs-model-v4)