### PR TITLE
Portal 1300/create upload page

### DIFF
--- a/upload-tool/App.tsx
+++ b/upload-tool/App.tsx
@@ -3,13 +3,6 @@ import React, { Fragment } from "react";
 import "@us-gov-cdc/cdc-react/dist/style.css";
 
 function App() {
-  // return (
-  //   <Router>
-  //     <Routes>
-  //       <Route path="/" element={<Landing />}></Route>
-  //     </Routes>
-  //   </Router>
-  // );
   return (
     <Fragment>
       <h1>File Upload</h1>

--- a/upload-tool/App.tsx
+++ b/upload-tool/App.tsx
@@ -1,0 +1,31 @@
+import React, { Fragment } from "react";
+
+import "@us-gov-cdc/cdc-react/dist/style.css";
+
+function App() {
+  // return (
+  //   <Router>
+  //     <Routes>
+  //       <Route path="/" element={<Landing />}></Route>
+  //     </Routes>
+  //   </Router>
+  // );
+  return (
+    <Fragment>
+      <h1>File Upload</h1>
+      <label htmlFor="portal-upload">Choose a file:</label>
+      <input
+        type="file"
+        id="portal-upload"
+        name="portal-upload"
+        accept=".csv,.hl7,.txt"
+      />
+      <p>
+        Accepted file types include .csv, .hl7, .txt | Limited to 1 file per
+        upload
+      </p>
+    </Fragment>
+  );
+}
+
+export default App;

--- a/upload-tool/index.html
+++ b/upload-tool/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>DEX Portal - Upload Tool</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./main.tsx"></script>
+  </body>
+</html>

--- a/upload-tool/main.tsx
+++ b/upload-tool/main.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import App from "./App";
+import "../src/index.css";
+
+ReactDOM.createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,6 @@
 import { UserConfig, configDefaults, defineConfig } from "vitest/config";
 import { viteStaticCopy } from "vite-plugin-static-copy";
+import { resolve } from "path";
 
 import react from "@vitejs/plugin-react";
 
@@ -15,6 +16,14 @@ export default defineConfig({
     }),
     react(),
   ],
+  build: {
+    rollupOptions: {
+      input: {
+        main: resolve(__dirname, "index.html"),
+        "upload-tool": resolve(__dirname, "upload-tool/index.html"),
+      },
+    },
+  },
   test: {
     globals: true,
     environment: "jsdom",


### PR DESCRIPTION
# Description

* Adds new directory for new DEX Portal Upload Tool `upload-tool`
* Updates config to enable multi-page support for vite and add `upload-tool`
* Adds basic page for Upload Tool
* Adds page title and input form (native HTML for now) for file picking

# Notes
* No routing or authentication added
* To view this new page you must navigate to this specific path: `/upload-tool/` (note the trailing slash. Without it, it will navigate to the main DEX Portal app)

# Testing
1. Checkout branch
2. `yarn run dev`
3. Navigate to `/upload-tool/`
4. Verify acceptance criteria

Resolves #1300- https://cdc-dexops.atlassian.net/browse/PORTAL-1300