### PR TITLE
Portal-1314/Create-Upload-Form

### DIFF
--- a/upload-tool/App.tsx
+++ b/upload-tool/App.tsx
@@ -1,23 +1,58 @@
-import React, { Fragment } from "react";
+import React from "react";
+
+import { Button, Divider } from "@us-gov-cdc/cdc-react";
+
+import { Icons } from "@us-gov-cdc/cdc-react-icons";
 
 import "@us-gov-cdc/cdc-react/dist/style.css";
 
 function App() {
+  const fileTypes = [".csv", ".hl7", ".txt"];
+
+  const handleFileUpload = () => {
+    document?.getElementById("file-uploader")?.click();
+  };
+
+  const handleInputChange = (e) => {
+    const file = document.getElementById("file-uploader")?.files[0];
+    const fileName = document.getElementById("file-name");
+    fileName.textContent = file.name;
+  };
+
   return (
-    <Fragment>
+    <React.Fragment>
       <h1>File Upload</h1>
-      <label htmlFor="portal-upload">Choose a file:</label>
-      <input
-        type="file"
-        id="portal-upload"
-        name="portal-upload"
-        accept=".csv,.hl7,.txt"
-      />
-      <p>
-        Accepted file types include .csv, .hl7, .txt | Limited to 1 file per
-        upload
+      <div className="display-flex flex-row flex-justify-start flex-align-center">
+        <div className="margin-right-2">
+          <Button
+            id="upload-button"
+            ariaLabel="Choose a file"
+            icon={<Icons.Folder />}
+            iconPosition="left"
+            size="big"
+            onClick={handleFileUpload}>
+            Choose a file
+          </Button>
+          <input
+            type="file"
+            id="file-uploader"
+            name="file-uploader"
+            accept={fileTypes.toString()}
+            multiple
+            onChange={(e) => handleInputChange(e)}
+          />
+        </div>
+        <p id="file-name" className="text-italic text-normal">
+          No file chosen
+        </p>
+      </div>
+      <p className="text-italic text-normal">
+        Accepted file types include .csv, .hl7, .txt{" "}
+        <span className="text-no-italic margin-x-105">|</span>Limited to 1 file
+        per upload
       </p>
-    </Fragment>
+      <Divider height={2} stroke="#000" width={1000} />
+    </React.Fragment>
   );
 }
 

--- a/upload-tool/main.tsx
+++ b/upload-tool/main.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
-import "../src/index.css";
+import "./styles.css";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>

--- a/upload-tool/styles.css
+++ b/upload-tool/styles.css
@@ -1,0 +1,3 @@
+#file-uploader {
+  display: none;
+}


### PR DESCRIPTION
# Description

Updates to upload tool:
* Hides default file input UI
* Use `cdc-react` button to handle file picker `.click()`
* Updates to improve style
* Adds divider
* Limits file selection to only three file extensions: `.csv` `.hl7` `.txt` (we should likely switch to use mime-types. I don't know if hl7 has a mime-type though)

# Notes
* No 3rd-party packages used so this is using browser APIs and manual event handlers for now
* Using USWDS utilities for styling/layout

# Testing
1. Checkout branch
2. Run build / `yarn run dev`
3. Verify file picker works
4. Verify only the above files with noted file extensions can be selected
5. Verify additional acceptance criteria in original story