### PR TITLE
Fixes LSP auto import functionality

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,10 +11,10 @@
     "skipLibCheck": true,
     "baseUrl": ".",
     "paths": {
-      "src": [
+      "src/*": [
         "./src/*"
       ],
-      "tests": [
+      "tests/*": [
         "./tests/*"
       ]
     },


### PR DESCRIPTION
Small change to tsconfig so that the LSP auto import feature imports to the exact file, rather than just to `src`. 