### PR TITLE
Moving mocked auth to the app.tsx file, rather than in protectedroute

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import "@us-gov-cdc/cdc-react/dist/style.css";
 
 import "src/App.css";
@@ -17,8 +18,14 @@ import Profile from "src/screens/Profile";
 import Submissions from "src/screens/Submissions";
 
 import { ProtectedRoute } from "src/components/ProtectedRoute";
+import { getEnv } from "src/utils/helperFunctions/env";
 
 function App() {
+  // ignore Auth if running locally with mocked data
+  const AuthWrapper = getEnv("VITE_DEV_MOCKING_ENABLED")
+    ? React.Fragment
+    : ProtectedRoute;
+
   return (
     <Router>
       <Routes>
@@ -26,9 +33,9 @@ function App() {
         <Route
           path="home/*"
           element={
-            <ProtectedRoute>
+            <AuthWrapper>
               <Shell />
-            </ProtectedRoute>
+            </AuthWrapper>
           }>
           <Route path="dashboard" element={<Dashboard />}></Route>
           <Route path="profile" element={<Profile />}></Route>

--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -8,9 +8,6 @@ export function ProtectedRoute({ children }: PropsWithChildren) {
   const navigate = useNavigate();
 
   useEffect(() => {
-    // ignore Auth if running locally with mocked data
-    if (getEnv("VITE_DEV_MOCKING_ENABLED")) return;
-
     if (
       !hasAuthParams() &&
       !auth.isAuthenticated &&


### PR DESCRIPTION
Conditionally wraps the Shell component in the ProtectedRoute based on the env variable that handles turning on Mock Service Worker. So if MSW is enabled, Auth is disabled. 