### PR TITLE
Portal-1675 Add check to only do a fetch when modal is open

### DIFF
--- a/src/components/DetailsModal.tsx
+++ b/src/components/DetailsModal.tsx
@@ -56,8 +56,10 @@ function DetailsModal({
         console.error("Failed to parse JSON:", error);
       }
     };
-    fetchCall();
-  }, [auth, submission]);
+    if (isModalOpen) {
+      fetchCall();
+    }
+  }, [auth, submission, isModalOpen]);
 
   const getContent = () => {
     if (submission.status == "failed") {


### PR DESCRIPTION
Current behavior: When navigating to Track Submissions page the ModalDetails is rendered and this attempt to do a fetch.
New behavior: When navigating to Track Submissions page the ModalDetails is rendered but only does a fetch when the modal is opened. 