### PR TITLE
Dynamic submission details created

### DIFF
--- a/@types/index.ts
+++ b/@types/index.ts
@@ -1,7 +1,0 @@
-export type IFileSubmission = {
-  readonly upload_id: string;
-  readonly filename: string;
-  readonly status: string;
-  readonly timestamp: string;
-  readonly validationReport?: object;
-};

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@nivo/pie": "^0.85.1",
     "@us-gov-cdc/cdc-react": "^1.11.0",
     "@us-gov-cdc/cdc-react-icons": "^2.5.0",
+    "date-fns": "^3.6.0",
     "msw": "^2.2.1",
     "oidc-client-ts": "^2.2.4",
     "react": "^18.2.0",

--- a/src/components/DetailsModal.tsx
+++ b/src/components/DetailsModal.tsx
@@ -72,7 +72,6 @@ function DetailsModal({
 
       try {
         const data = (await res.json()) as SubmissionDetails;
-        console.log(data);
         setDetails(data);
       } catch (error) {
         console.error("Failed to parse JSON:", error);

--- a/src/components/DetailsModal.tsx
+++ b/src/components/DetailsModal.tsx
@@ -14,17 +14,17 @@ import {
 } from "@us-gov-cdc/cdc-react";
 
 import { Icons } from "@us-gov-cdc/cdc-react-icons";
-import { IFileSubmission } from "@types";
 import getStatusDisplayValuesById, {
   StatusDisplayValues,
 } from "src/utils/helperFunctions/statusDisplayValues";
 import jsonPrettyPrint from "src/utils/helperFunctions/jsonPrettyPrint";
-import getSubmissionDetails from "src/utils/api/submissionDetails";
-// TODO: replace with mocks from useEffect
-import { mockValidationReports } from "src/mocks/data/submissionDetails";
+import getSubmissionDetails, {
+  SubmissionDetails,
+} from "src/utils/api/submissionDetails";
+import { FileSubmission } from "src/utils/api/fileSubmissions";
 
 interface PropTypes {
-  submission: IFileSubmission;
+  submission: FileSubmission;
   isModalOpen: boolean;
   handleModalClose: () => void;
 }
@@ -38,7 +38,22 @@ function DetailsModal({
     submission.status
   );
   const auth = useAuth();
-  const [details, setDetails] = useState();
+  const [details, setDetails] = useState<SubmissionDetails>({
+    info: {
+      status: submission.status,
+      stage_name: "",
+      file_name: submission.filename,
+      file_size_bytes: 0,
+      bytes_uploaded: 0,
+      upload_id: submission.upload_id,
+      uploaded_by: "",
+      timestamp: submission.timestamp,
+      data_stream_id: submission.data_stream_id,
+      data_stream_route: submission.data_stream_route,
+    },
+    issues: [],
+    reports: [],
+  });
 
   useEffect(() => {
     const fetchCall = async () => {
@@ -50,7 +65,7 @@ function DetailsModal({
       if (res.status != 200) return;
 
       try {
-        const data = await res.json();
+        const data = (await res.json()) as SubmissionDetails;
         setDetails(data);
       } catch (error) {
         console.error("Failed to parse JSON:", error);
@@ -63,17 +78,16 @@ function DetailsModal({
 
   const getContent = () => {
     if (submission.status == "failed") {
-      // TODO: parse file details from useEffect for failed alert data
       return (
-        <Alert heading="Failed Metadata" type="error">
-          2 Errors were detected
-          <p className="border-1px radius-md border-secondary-light margin-y-2 padding-105">
-            Missing required metadata field, meta_field1.
-          </p>
-          <p className="border-1px radius-md border-secondary-light margin-y-2 padding-105">
-            Metadata field, meta_field2, is set to value3 and does not contain
-            one of the allowed values: [value1, value2]
-          </p>
+        <Alert heading="Failed" type="error">
+          {details.issues.length} Error(s) were detected
+          {details.issues.map((issue: string) => (
+            <p
+              key={issue}
+              className="border-1px radius-md border-secondary-light margin-y-2 padding-105">
+              {issue}
+            </p>
+          ))}
         </Alert>
       );
     }
@@ -83,12 +97,15 @@ function DetailsModal({
     }
 
     if (submission.status == "processing") {
-      // TODO: parse file details for stage, current upload amount, total upload amount, etc. from useEffect
+      const total = Math.floor(details.info.file_size_bytes / (1024 * 1024));
+      const currentAmount = Math.floor(
+        details.info.bytes_uploaded / (1024 * 1024)
+      );
       return (
         <ProgressTracker
           label="Stage: Uploading"
-          currentAmount={55}
-          totalAmount={256}
+          currentAmount={currentAmount}
+          totalAmount={total}
         />
       );
     }
@@ -120,15 +137,13 @@ function DetailsModal({
           <div className="grid-col-4">
             <strong>Uploaded by</strong>
           </div>
-          <div className="grid-col-8">
-            MarylandStateSender123 Jurisdiction Parter
-          </div>
+          <div className="grid-col-8">{details.info.uploaded_by}</div>
         </div>
         <div className="grid-row margin-y-1">
           <div className="grid-col-4">
             <strong>Upload date</strong>
           </div>
-          <div className="grid-col-8">Tuesday, March 5, 2024 | 3:45 pm</div>
+          <div className="grid-col-8">{details.info.timestamp}</div>
         </div>
         <div className="grid-row margin-y-1">
           <div className="grid-col-4">
@@ -137,25 +152,22 @@ function DetailsModal({
           <div className="grid-col-8">{submission.upload_id}</div>
         </div>
         <div className="grid-row margin-top-3">
-          {/* TODO: replace with real data from useEffect submissionDetails calls */}
           <Accordion
             items={[
               {
                 id: "1",
                 title: "Submitted details",
-                content: jsonPrettyPrint(details),
+                content: jsonPrettyPrint(details.info),
               },
             ]}
           />
-          {/* Todo: This logic is for purposes of showing a mock validation report and should be revisited
-            once the data structure is finalized.  */}
-          {submission.status === "failed" && (
+          {submission.status === "failed" && details.reports.length > 0 && (
             <Accordion
               items={[
                 {
                   id: "2",
                   title: "Validation report",
-                  content: jsonPrettyPrint(mockValidationReports),
+                  content: jsonPrettyPrint(details.reports),
                 },
               ]}
             />

--- a/src/components/DetailsModal.tsx
+++ b/src/components/DetailsModal.tsx
@@ -12,6 +12,7 @@ import {
   Pill,
   ProgressTracker,
 } from "@us-gov-cdc/cdc-react";
+import { format, parseISO } from "date-fns";
 
 import { Icons } from "@us-gov-cdc/cdc-react-icons";
 import getStatusDisplayValuesById, {
@@ -55,6 +56,11 @@ function DetailsModal({
     reports: [],
   });
 
+  const formatDate = (date?: string) => {
+    if (!date) return "";
+    return format(parseISO(date), "EEEE, MMMM d, yyyy ' | ' h:mm a");
+  };
+
   useEffect(() => {
     const fetchCall = async () => {
       const res = await getSubmissionDetails(
@@ -66,6 +72,7 @@ function DetailsModal({
 
       try {
         const data = (await res.json()) as SubmissionDetails;
+        console.log(data);
         setDetails(data);
       } catch (error) {
         console.error("Failed to parse JSON:", error);
@@ -143,7 +150,7 @@ function DetailsModal({
           <div className="grid-col-4">
             <strong>Upload date</strong>
           </div>
-          <div className="grid-col-8">{details.info.timestamp}</div>
+          <div className="grid-col-8">{formatDate(submission.timestamp)}</div>
         </div>
         <div className="grid-row margin-y-1">
           <div className="grid-col-4">

--- a/src/components/DetailsModal.tsx
+++ b/src/components/DetailsModal.tsx
@@ -109,7 +109,8 @@ function DetailsModal({
       );
       return (
         <ProgressTracker
-          label="Stage: Uploading"
+          label={`Stage: ${details.info.stage_name}`}
+          isIndeterminate={details.info.stage_name === "dex-hl7-validation"}
           currentAmount={currentAmount}
           totalAmount={total}
         />

--- a/src/mocks/data/fileSubmissions.ts
+++ b/src/mocks/data/fileSubmissions.ts
@@ -24,10 +24,8 @@ const generateFileSubmission = (
     filename: faker.system.commonFileName(route),
     status: faker.helpers.arrayElement(weightedStatuses),
     timestamp: faker.date.recent({ days: 40 }).toISOString(),
-    metadata: [
-      { key: "data_stream_id", value: dataStream },
-      { key: "data_stream_route", value: route },
-    ],
+    data_stream_id: dataStream,
+    data_stream_route: route,
   };
   return submission;
 };

--- a/src/mocks/data/submissionDetails.ts
+++ b/src/mocks/data/submissionDetails.ts
@@ -67,7 +67,7 @@ const generateSubmissionDetails = (
   return details;
 };
 
-const mockDetails = (): SubmissionDetails[] => {
+const buildMockDetails = (): SubmissionDetails[] => {
   const detailsAims: SubmissionDetails[] = mockSubmissions.aimsAll.items.map(
     (el: FileSubmission) => generateSubmissionDetails(el)
   );
@@ -77,49 +77,12 @@ const mockDetails = (): SubmissionDetails[] => {
   return [...detailsAims, ...detailsDaart];
 };
 
+export const mockDetails = buildMockDetails();
+
 const getMockDetails = (upload_id: string): SubmissionDetails | undefined => {
-  return mockDetails().find(
+  return mockDetails.find(
     (el: SubmissionDetails) => el.info.upload_id == upload_id
   );
-};
-
-export const mockSubmissionDetails = {
-  status: "Uploading",
-  tracing: [
-    {
-      stage: "dex-upload",
-      timestamp: "2024-03-27T17:19:19.909Z",
-    },
-  ],
-  file_name: "largefile.csv",
-  file_size_bytes: 190840042,
-  bytes_uploaded: 124046027,
-  upload_id: "8923c9ff-6afa-42b2-a67b-89cb37e047e6",
-  uploaded_by: "Jane Doe",
-  timestamp: "2024-03-27T17:19:19.909Z",
-  data_stream_id: "aims-celr",
-  data_stream_route: "csv",
-};
-
-export const mockValidationReports = {
-  upload_id: "6f8010917c0acc4dd329d21625ce1144",
-  data_stream_id: "aims-celr",
-  data_stream_route: "hl7",
-  reports: [
-    {
-      report_id: "a9c632ca-6614-4bd0-9f3a-03fe23466c35",
-      stage_name: "dex-routing",
-      timestamp: "2024-03-23T12:24:36.448Z",
-      content: {
-        result: "success",
-        schema_version: "0.0.1",
-        file_destination_blob_url: "https://url-to-file-location.txt",
-        file_source_blob_url: "https://url-to-file-source.txt",
-        schema_name: "dex-file-copy",
-        timestamp: "2024-03-23T12:24:36.431+0000",
-      },
-    },
-  ],
 };
 
 export default getMockDetails;

--- a/src/mocks/data/submissionDetails.ts
+++ b/src/mocks/data/submissionDetails.ts
@@ -1,30 +1,104 @@
+import { faker } from "@faker-js/faker";
+import {
+  SubmissionDetails,
+  ValidationReport,
+} from "src/utils/api/submissionDetails";
+import { FileSubmission } from "src/utils/api/fileSubmissions";
+import mockSubmissions from "src/mocks/data/fileSubmissions";
+
+const getIssues = (submission: FileSubmission): string[] => {
+  if (submission.status != "failed") return [];
+
+  return submission.data_stream_route == "csv"
+    ? [
+        "Missing required metadata field, 'meta_field1'.",
+        "Metadata field, 'meta_field2' is set to 'value3' and does not contain one of the allowed values: [ 'value1', value2' ]",
+      ]
+    : ["Hl7 Validation Error -- See validation report"];
+};
+
+const getValidationReport = (): ValidationReport => {
+  return {
+    line: faker.number.int({ min: 1, max: 5 }),
+    column: faker.number.int({ min: 1, max: 100 }),
+    path: "OBX[1]-5[1]",
+    description:
+      "The primitive Field OBX-5 (Observation Value) contains at least one unescaped delimiter",
+    category: "Unescaped Separator",
+    classification: "Error",
+  };
+};
+
+const getReports = (submission: FileSubmission): ValidationReport[] => {
+  if (submission.status == "failed" && submission.data_stream_route == "hl7") {
+    const numOfReports = faker.number.int({ min: 1, max: 3 });
+    const reports: ValidationReport[] = [];
+    for (let i = 0; i < numOfReports; i++) {
+      reports.push(getValidationReport());
+    }
+    return reports;
+  }
+  return [];
+};
+
+const generateSubmissionDetails = (
+  submission: FileSubmission
+): SubmissionDetails => {
+  const fileSize = faker.number.int({ min: 1000000, max: 200000000 });
+  const details: SubmissionDetails = {
+    info: {
+      status: submission.status,
+      stage_name:
+        submission.data_stream_route == "hl7"
+          ? "dex-hl7-validation"
+          : "dex-uploading",
+      file_name: submission.filename,
+      file_size_bytes: fileSize,
+      bytes_uploaded: faker.number.int({ min: 0, max: fileSize }),
+      upload_id: submission.upload_id,
+      uploaded_by: faker.internet.userName(),
+      timestamp: submission.timestamp,
+      data_stream_id: submission.data_stream_id,
+      data_stream_route: submission.data_stream_route,
+    },
+    issues: getIssues(submission),
+    reports: getReports(submission),
+  };
+  return details;
+};
+
+const mockDetails = (): SubmissionDetails[] => {
+  const detailsAims: SubmissionDetails[] = mockSubmissions.aimsAll.items.map(
+    (el: FileSubmission) => generateSubmissionDetails(el)
+  );
+  const detailsDaart: SubmissionDetails[] = mockSubmissions.daartHl7.items.map(
+    (el: FileSubmission) => generateSubmissionDetails(el)
+  );
+  return [...detailsAims, ...detailsDaart];
+};
+
+const getMockDetails = (upload_id: string): SubmissionDetails | undefined => {
+  return mockDetails().find(
+    (el: SubmissionDetails) => el.info.upload_id == upload_id
+  );
+};
+
 export const mockSubmissionDetails = {
   status: "Uploading",
   tracing: [
     {
       stage: "dex-upload",
       timestamp: "2024-03-27T17:19:19.909Z",
-      tags: [
-        {
-          key: "string",
-          value: "string",
-        },
-      ],
     },
   ],
-  percent_complete: 0.65,
   file_name: "largefile.csv",
   file_size_bytes: 190840042,
   bytes_uploaded: 124046027,
-  tus_upload_id: "8923c9ff-6afa-42b2-a67b-89cb37e047e6",
-  time_uploading_sec: 34.4,
-  timestamp: "string",
-  metadata: [
-    {
-      key: "string",
-      value: "string",
-    },
-  ],
+  upload_id: "8923c9ff-6afa-42b2-a67b-89cb37e047e6",
+  uploaded_by: "Jane Doe",
+  timestamp: "2024-03-27T17:19:19.909Z",
+  data_stream_id: "aims-celr",
+  data_stream_route: "csv",
 };
 
 export const mockValidationReports = {
@@ -47,3 +121,5 @@ export const mockValidationReports = {
     },
   ],
 };
+
+export default getMockDetails;

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -6,7 +6,7 @@ import { FileSubmissions } from "src/utils/api/fileSubmissions";
 import { generateCounts } from "src/mocks/data/reportCounts";
 import mockSubmissions, { dateFilter } from "src/mocks/data/fileSubmissions";
 import mockDataStreams from "src/mocks/data/dataStreams.json";
-import { mockSubmissionDetails } from "src/mocks/data/submissionDetails";
+import getMockDetails from "src/mocks/data/submissionDetails";
 
 const earliestDate: string = new Date("2021-01-01T05:00:00Z").toISOString();
 
@@ -73,6 +73,8 @@ export const handlers = [
       return new HttpResponse(null, { status: 400 });
     }
 
-    return HttpResponse.json(mockSubmissionDetails);
+    const details = getMockDetails(upload_id);
+
+    return HttpResponse.json(details);
   }),
 ];

--- a/src/screens/Submissions.tsx
+++ b/src/screens/Submissions.tsx
@@ -19,11 +19,12 @@ import {
 } from "@us-gov-cdc/cdc-react";
 import { Icons } from "@us-gov-cdc/cdc-react-icons";
 
-import { IFileSubmission } from "@types";
 import {
+  FileSubmission,
   FileSubmissions,
   FileSubmissionsSummary,
-  defaultSummary,
+  defaultSubmissionItem,
+  defaultSubmissionSummary,
   getFileSubmissions,
 } from "src/utils/api/fileSubmissions";
 import getStatusDisplayValuesById from "src/utils/helperFunctions/statusDisplayValues";
@@ -37,22 +38,18 @@ import { getPastDate } from "src/utils/helperFunctions/date";
 function Submissions() {
   const auth = useAuth();
   const pageLimit = 10;
-  const [currentPageData, setCurrentPageData] = useState<IFileSubmission[]>([]);
-  const [dataSummary, setDataSummary] =
-    useState<FileSubmissionsSummary>(defaultSummary);
+  const [currentPageData, setCurrentPageData] = useState<FileSubmission[]>([]);
+  const [dataSummary, setDataSummary] = useState<FileSubmissionsSummary>(
+    defaultSubmissionSummary
+  );
 
   const dataStreamId = useRecoilValue(dataStreamIdAtom);
   const dataRoute = useRecoilValue(dataRouteAtom);
   const timeframe = useRecoilValue(timeFrameAtom);
 
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const [selectedSubmission, setSelectedSubmission] = useState<IFileSubmission>(
-    {
-      upload_id: "",
-      filename: "",
-      status: "",
-      timestamp: "",
-    }
+  const [selectedSubmission, setSelectedSubmission] = useState<FileSubmission>(
+    defaultSubmissionItem
   );
 
   useEffect(() => {
@@ -127,7 +124,7 @@ function Submissions() {
               </TableRow>
             </TableHead>
             <TableBody>
-              {currentPageData.map((item: IFileSubmission) => (
+              {currentPageData.map((item: FileSubmission) => (
                 <TableRow key={`table-row-${item.upload_id}`}>
                   {/* Todo: Update this to use a more appropriate id as key */}
                   <TableDataCell className="text-left">

--- a/src/utils/api/fileSubmissions.ts
+++ b/src/utils/api/fileSubmissions.ts
@@ -21,11 +21,20 @@ export interface FileSubmissions {
   items: FileSubmission[];
 }
 
-export const defaultSummary: FileSubmissionsSummary = {
+export const defaultSubmissionSummary: FileSubmissionsSummary = {
   number_of_pages: 0,
   page_number: 1,
   page_size: 10,
   total_items: 0,
+};
+
+export const defaultSubmissionItem: FileSubmission = {
+  upload_id: "",
+  filename: "",
+  status: "",
+  timestamp: "",
+  data_stream_id: "",
+  data_stream_route: "",
 };
 
 export const getFileSubmissions = async (

--- a/src/utils/api/fileSubmissions.ts
+++ b/src/utils/api/fileSubmissions.ts
@@ -1,10 +1,5 @@
 import API_ENDPOINTS from "src/config/api";
 
-export interface FileSubmissionMetadata {
-  key: string;
-  value: string;
-}
-
 export interface FileSubmissionsSummary {
   number_of_pages: number;
   page_number: number;
@@ -17,7 +12,8 @@ export interface FileSubmission {
   filename: string;
   status: string;
   timestamp: string;
-  metadata: FileSubmissionMetadata[];
+  data_stream_id: string;
+  data_stream_route: string;
 }
 
 export interface FileSubmissions {

--- a/src/utils/api/submissionDetails.ts
+++ b/src/utils/api/submissionDetails.ts
@@ -1,5 +1,33 @@
 import API_ENDPOINTS from "src/config/api";
 
+export interface ValidationReport {
+  line: number;
+  column: number;
+  path: string;
+  description: string;
+  category: string;
+  classification: string;
+}
+
+export interface SubmissionInfo {
+  status: string;
+  stage_name: string;
+  file_name: string;
+  file_size_bytes: number;
+  bytes_uploaded: number;
+  upload_id: string;
+  uploaded_by: string;
+  timestamp: string;
+  data_stream_id: string;
+  data_stream_route: string;
+}
+
+export interface SubmissionDetails {
+  info: SubmissionInfo;
+  issues: string[];
+  reports: ValidationReport[];
+}
+
 export const getSubmissionDetails = async (
   access_token: string,
   upload_id: string

--- a/tests/unit/utils/api/submissionDetails.test.ts
+++ b/tests/unit/utils/api/submissionDetails.test.ts
@@ -1,10 +1,13 @@
 import getSubmissionDetails from "src/utils/api/submissionDetails";
-import { mockSubmissionDetails } from "src/mocks/data/submissionDetails";
+import getMockDetails from "src/mocks/data/submissionDetails";
+import mockSubmissions from "src/mocks/data/fileSubmissions";
 
 describe("submissionDetails", () => {
   it("should fetch submission details", async () => {
-    const payload = mockSubmissionDetails;
-    const res = await getSubmissionDetails("mock_auth_token", "mock_upload_id");
+    const firstSubmission = mockSubmissions.aimsCsv.items[0];
+    const upload_id = firstSubmission.upload_id;
+    const payload = getMockDetails(upload_id);
+    const res = await getSubmissionDetails("mock_auth_token", upload_id);
     const data = await res.json();
 
     expect(data).toStrictEqual(payload);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2546,6 +2546,11 @@ date-fns@^2.29.1:
   dependencies:
     "@babel/runtime" "^7.21.0"
 
+date-fns@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-3.6.0.tgz#f20ca4fe94f8b754951b24240676e8618c0206bf"
+  integrity sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==
+
 debug@2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"


### PR DESCRIPTION
Related to this ticket: https://cdc-dexops.atlassian.net/jira/software/c/projects/PORTAL/boards/34?assignee=712020%3A7a51fc62-e228-4429-9236-e8825a21abd6&selectedIssue=PORTAL-1687

- Submission Details are now more thoroughly mocked
- Failed has two states, one for hl7, and one for csv
- processing has two states, one for hl7 and one for csv
- timestamp, upload_id, filename, etc are all directly linked to the submission clicked on in the table