### PR TITLE
Portal 1791/add dropdowns

### DIFF
--- a/src/components/SearchOptions.tsx
+++ b/src/components/SearchOptions.tsx
@@ -21,9 +21,13 @@ import timeframes, { Timeframe } from "src/types/timeframes";
 
 interface SearchOptionsProps {
   forSubmissions?: boolean;
+  handleFilter?: () => void;
 }
 
-function SearchOptions({ forSubmissions = false }: SearchOptionsProps) {
+function SearchOptions({
+  forSubmissions = false,
+  handleFilter,
+}: SearchOptionsProps) {
   const [searchParams, setSearchParams] = useSearchParams();
   const [data_stream_id, setDataStreamId] = useRecoilState(dataStreamIdAtom);
   const [data_route, setDataRoute] = useRecoilState(dataRouteAtom);
@@ -48,6 +52,8 @@ function SearchOptions({ forSubmissions = false }: SearchOptionsProps) {
   }, []);
 
   useEffect(() => {
+    if (handleFilter) handleFilter();
+
     setSearchParams({
       data_stream_id,
       data_route,

--- a/src/components/SearchOptions.tsx
+++ b/src/components/SearchOptions.tsx
@@ -67,6 +67,7 @@ function SearchOptions({
     jurisdiction,
     sender_id,
     timeframe,
+    handleFilter,
     setSearchParams,
   ]);
 

--- a/src/components/SearchOptions.tsx
+++ b/src/components/SearchOptions.tsx
@@ -4,6 +4,8 @@ import { useRecoilState, useRecoilValue } from "recoil";
 import {
   dataRouteAtom,
   dataStreamIdAtom,
+  jurisdictionAtom,
+  senderIdAtom,
   timeFrameAtom,
 } from "src/state/searchParams";
 import { dataStreamsAtom } from "src/state/dataStreams";
@@ -17,27 +19,50 @@ import {
 } from "src/utils/helperFunctions/dataStreams";
 import timeframes, { Timeframe } from "src/types/timeframes";
 
-function SearchOptions() {
+interface SearchOptionsProps {
+  forSubmissions?: boolean;
+}
+
+function SearchOptions({ forSubmissions = false }: SearchOptionsProps) {
   const [searchParams, setSearchParams] = useSearchParams();
   const [data_stream_id, setDataStreamId] = useRecoilState(dataStreamIdAtom);
   const [data_route, setDataRoute] = useRecoilState(dataRouteAtom);
   const [timeframe, setTimeframe] = useRecoilState(timeFrameAtom);
+  const [jurisdiction, setJurisdiction] = useRecoilState(jurisdictionAtom);
+  const [sender_id, setSenderId] = useRecoilState(senderIdAtom);
   const dataStreams = useRecoilValue(dataStreamsAtom);
 
   useEffect(() => {
     const streamId = searchParams.get("data_stream_id");
     const route = searchParams.get("data_route");
-    const timeframe = searchParams.get("timeframe") as Timeframe;
+    const tf = searchParams.get("timeframe") as Timeframe;
+    const jd = searchParams.get("jurisdiction");
+    const senderId = searchParams.get("sender_id");
 
     if (streamId) setDataStreamId(streamId);
     if (route) setDataRoute(route);
-    if (timeframe) setTimeframe(timeframe);
+    if (tf) setTimeframe(tf);
+    if (jd) setJurisdiction(jd);
+    if (senderId) setSenderId(senderId);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   useEffect(() => {
-    setSearchParams({ data_stream_id, data_route, timeframe });
-  }, [data_stream_id, data_route, timeframe, setSearchParams]);
+    setSearchParams({
+      data_stream_id,
+      data_route,
+      jurisdiction,
+      sender_id,
+      timeframe,
+    });
+  }, [
+    data_stream_id,
+    data_route,
+    jurisdiction,
+    sender_id,
+    timeframe,
+    setSearchParams,
+  ]);
 
   const handleDataStreamId = (dataStreamId: string) => {
     setDataStreamId(dataStreamId);
@@ -52,6 +77,14 @@ function SearchOptions() {
   const handleTimeframe = (time: string) => {
     const timeframe = time as Timeframe;
     setTimeframe(timeframe);
+  };
+
+  const handleJurisdiction = (jd: string) => {
+    setJurisdiction(jd);
+  };
+
+  const handleSender = (senderId: string) => {
+    setSenderId(senderId);
   };
 
   return (
@@ -74,6 +107,7 @@ function SearchOptions() {
           defaultValue={data_route}
         />
         <Dropdown
+          className="padding-right-2"
           items={timeframes}
           label="Timeframe"
           labelIcon={<Icons.Calendar />}
@@ -81,6 +115,26 @@ function SearchOptions() {
           srText="Timeframe"
           defaultValue={timeframe}
         />
+        {forSubmissions && (
+          <>
+            <Dropdown
+              className="padding-right-2"
+              items={["MD", "VA"]}
+              label="Jurisdiction"
+              onSelect={handleJurisdiction}
+              srText="Jurisdiction"
+              defaultValue={jurisdiction}
+            />
+            <Dropdown
+              className="padding-right-2"
+              items={["Sender 1", "Sender 2"]}
+              label="Sender"
+              onSelect={handleSender}
+              srText="Sender"
+              defaultValue={sender_id}
+            />
+          </>
+        )}
       </div>
     </div>
   );

--- a/src/components/SearchOptions.tsx
+++ b/src/components/SearchOptions.tsx
@@ -87,6 +87,60 @@ function SearchOptions({ forSubmissions = false }: SearchOptionsProps) {
     setSenderId(senderId);
   };
 
+  const jurisdictions = [
+    "All",
+    "USA-AL",
+    "USA-AK",
+    "USA-AZ",
+    "USA-AR",
+    "USA-CA",
+    "USA-CO",
+    "USA-CT",
+    "USA-DE",
+    "USA-FL",
+    "USA-GA",
+    "USA-HI",
+    "USA-ID",
+    "USA-IL",
+    "USA-IN",
+    "USA-IA",
+    "USA-KS",
+    "USA-KY",
+    "USA-LA",
+    "USA-ME",
+    "USA-MD",
+    "USA-MA",
+    "USA-MI",
+    "USA-MN",
+    "USA-MS",
+    "USA-MO",
+    "USA-MT",
+    "USA-NE",
+    "USA-NV",
+    "USA-NH",
+    "USA-NJ",
+    "USA-NM",
+    "USA-NY",
+    "USA-NC",
+    "USA-ND",
+    "USA-OH",
+    "USA-OK",
+    "USA-OR",
+    "USA-PA",
+    "USA-RI",
+    "USA-SC",
+    "USA-SD",
+    "USA-TN",
+    "USA-TX",
+    "USA-UT",
+    "USA-VT",
+    "USA-VA",
+    "USA-WA",
+    "USA-WV",
+    "USA-WI",
+    "USA-WY",
+  ];
+
   return (
     <div className="padding-bottom-2 display-flex flex-row flex-justify">
       <div className="display-flex flex-row cdc-submissions-page--filters">
@@ -119,7 +173,7 @@ function SearchOptions({ forSubmissions = false }: SearchOptionsProps) {
           <>
             <Dropdown
               className="padding-right-2"
-              items={["MD", "VA"]}
+              items={jurisdictions}
               label="Jurisdiction"
               onSelect={handleJurisdiction}
               srText="Jurisdiction"
@@ -127,7 +181,15 @@ function SearchOptions({ forSubmissions = false }: SearchOptionsProps) {
             />
             <Dropdown
               className="padding-right-2"
-              items={["Sender 1", "Sender 2"]}
+              items={[
+                "All",
+                "PH-LA",
+                "ST-LA",
+                "LB-LA",
+                "CO-LA",
+                "HO-LA",
+                "PR-LA",
+              ]}
               label="Sender"
               onSelect={handleSender}
               srText="Sender"

--- a/src/mocks/data/fileSubmissions.ts
+++ b/src/mocks/data/fileSubmissions.ts
@@ -206,18 +206,33 @@ export const getSubmissions = (
   sortBy: string,
   sortOrder: string,
   pageNumber: number,
-  pageSize: number
+  pageSize: number,
+  jurisdiction: string,
+  senderId: string
 ): FileSubmissions => {
   const dateFilteredItems = dateFilter(submissions, startDate);
 
+  const jurisdictionFilter = jurisdiction
+    ? dateFilteredItems.filter(
+        (el: FileSubmission) =>
+          jurisdiction == "All" || el.jurisdiction == jurisdiction
+      )
+    : dateFilteredItems;
+
+  const senderFilter = senderId
+    ? jurisdictionFilter.filter(
+        (el: FileSubmission) => senderId == "All" || el.sender == senderId
+      )
+    : jurisdictionFilter;
+
   const summary: FileSubmissionsSummary = generateSummary(
-    dateFilteredItems,
+    senderFilter,
     pageNumber,
     pageSize
   );
 
   const sortedItems: FileSubmission[] = sortSubmissions(
-    dateFilteredItems,
+    senderFilter,
     sortBy,
     sortOrder
   );

--- a/src/mocks/handlers/mmsHandlers.ts
+++ b/src/mocks/handlers/mmsHandlers.ts
@@ -295,8 +295,8 @@ export const mmsHandlers = [
   http.get(`${API_ENDPOINTS.identities}`, () => {
     // Todo: Switch to using a mock data object instead of hardcoding
     return HttpResponse.json([
-      { id: "1", name: "identity1" },
-      { id: "2", name: "identity2" },
+      { id: "1", idpClientID: "identity1" },
+      { id: "2", idpClientID: "identity2" },
     ]);
   }),
 

--- a/src/mocks/handlers/psApiHandlers.ts
+++ b/src/mocks/handlers/psApiHandlers.ts
@@ -21,6 +21,8 @@ export const psApiHandlers = [
     const sortOrder = url.searchParams.get("sort_order") ?? "descending";
     const pageNumber = url.searchParams.get("page_number");
     const pageSize = url.searchParams.get("page_size");
+    const jurisdiction = url.searchParams.get("jurisdiction");
+    const senderId = url.searchParams.get("sender_id");
 
     const submissionsResponse = (submissions: FileSubmission[]) => {
       return HttpResponse.json(
@@ -30,7 +32,9 @@ export const psApiHandlers = [
           sortBy,
           sortOrder,
           pageNumber ? parseInt(pageNumber) : 1,
-          pageSize ? parseInt(pageSize) : 10
+          pageSize ? parseInt(pageSize) : 10,
+          jurisdiction ?? "",
+          senderId ?? ""
         )
       );
     };
@@ -65,7 +69,9 @@ export const psApiHandlers = [
             "filename",
             "descending",
             1,
-            150
+            150,
+            "All",
+            "All"
           )
         )
       );

--- a/src/screens/Submissions.tsx
+++ b/src/screens/Submissions.tsx
@@ -4,6 +4,8 @@ import {
   dataRouteAtom,
   dataStreamIdAtom,
   timeFrameAtom,
+  jurisdictionAtom,
+  senderIdAtom,
 } from "src/state/searchParams";
 
 import { Button, Pill } from "@us-gov-cdc/cdc-react";
@@ -53,6 +55,8 @@ function Submissions() {
   const dataStreamId = useRecoilValue(dataStreamIdAtom);
   const dataRoute = useRecoilValue(dataRouteAtom);
   const timeframe = useRecoilValue(timeFrameAtom);
+  const jurisdiction = useRecoilValue(jurisdictionAtom);
+  const senderId = useRecoilValue(senderIdAtom);
 
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [selectedSubmission, setSelectedSubmission] = useState<FileSubmission>(
@@ -125,7 +129,9 @@ function Submissions() {
         sorting.length > 0 ? sorting[0].id : "timestamp",
         sortDirection(),
         pagination.pageIndex + 1,
-        pagination.pageSize
+        pagination.pageSize,
+        jurisdiction,
+        senderId
       );
 
       // TODO: add UI feedback for failed fileSubmission retrieval
@@ -147,7 +153,16 @@ function Submissions() {
     };
 
     if (dataStreamId) fetchCall();
-  }, [auth, dataStreamId, dataRoute, sorting, timeframe, pagination]);
+  }, [
+    auth,
+    dataStreamId,
+    dataRoute,
+    jurisdiction,
+    senderId,
+    sorting,
+    timeframe,
+    pagination,
+  ]);
 
   const handleSetSorting = (action: React.SetStateAction<SortingState>) => {
     setSorting(action);

--- a/src/screens/Submissions.tsx
+++ b/src/screens/Submissions.tsx
@@ -169,6 +169,10 @@ function Submissions() {
     table.setPageIndex(0);
   };
 
+  const handleFilter = () => {
+    table.setPageIndex(0);
+  };
+
   const table = useReactTable({
     data: currentPageData,
     state: {
@@ -195,7 +199,7 @@ function Submissions() {
       <h1 className="cdc-page-header padding-y-3 margin-0">
         Track Submissions
       </h1>
-      <SearchOptions forSubmissions />
+      <SearchOptions forSubmissions handleFilter={handleFilter} />
       {currentPageData.length === 0 ? (
         <p className="text-base font-sans-sm padding-top-3">
           No items found. Try expanding the timeframe or modifying the filters.

--- a/src/screens/Submissions.tsx
+++ b/src/screens/Submissions.tsx
@@ -103,14 +103,20 @@ function Submissions() {
 
   useEffect(() => {
     const fetchCall = async () => {
+      const sortDirection = () => {
+        if (sorting.length == 0) return "descending";
+
+        return sorting[0].desc ? "descending" : "ascending";
+      };
+
       const res = await getFileSubmissions(
         auth.user?.access_token || "",
         dataStreamId,
         dataRoute != "All" ? dataRoute : "",
         getPastDate(timeframe),
         new Date().toISOString(),
-        sorting.length > 0 ? sorting[0].id : "date",
-        sorting.length > 0 && sorting[0].desc ? "descending" : "ascending",
+        sorting.length > 0 ? sorting[0].id : "timestamp",
+        sortDirection(),
         pagination.pageIndex + 1,
         pagination.pageSize
       );
@@ -167,7 +173,7 @@ function Submissions() {
       <h1 className="cdc-page-header padding-y-3 margin-0">
         Track Submissions
       </h1>
-      <SearchOptions />
+      <SearchOptions forSubmissions />
       {currentPageData.length === 0 ? (
         <p className="text-base font-sans-sm padding-top-3">
           No items found. Try expanding the timeframe or modifying the filters.

--- a/src/state/searchParams.ts
+++ b/src/state/searchParams.ts
@@ -15,3 +15,13 @@ export const timeFrameAtom = atom<Timeframe>({
   key: "timeframe",
   default: Timeframe.Last7Days,
 });
+
+export const jurisdictionAtom = atom<string>({
+  key: "jurisdiction",
+  default: "",
+});
+
+export const senderIdAtom = atom<string>({
+  key: "senderId",
+  default: "",
+});

--- a/src/utils/api/fileSubmissions.ts
+++ b/src/utils/api/fileSubmissions.ts
@@ -50,7 +50,9 @@ export const getFileSubmissions = async (
   sort_by?: string,
   sort_order?: string,
   page_number?: number,
-  page_size?: number
+  page_size?: number,
+  jurisdiction?: string,
+  senderId?: string
 ): Promise<Response> => {
   const params = new URLSearchParams();
 
@@ -62,6 +64,8 @@ export const getFileSubmissions = async (
   if (sort_order) params.append("sort_order", sort_order);
   if (page_size) params.append("page_size", page_size.toString());
   if (page_number) params.append("page_number", page_number.toString());
+  if (jurisdiction) params.append("jurisdiction", jurisdiction);
+  if (senderId) params.append("sender_id", senderId);
 
   const url = `${API_ENDPOINTS.fileSubmissions}?${params.toString()}`;
 


### PR DESCRIPTION
Connected to this ticket: https://cdc-dexops.atlassian.net/browse/PORTAL-1768

- dropdowns for Jurisdiction and Sender filters added
- url params update when selection is made
- value is passed to PS-API call
- mocks updated

TODO: Figure out how the dropdown values will be loaded